### PR TITLE
String not quoted when dump trio file

### DIFF
--- a/shaystack/triodumper.py
+++ b/shaystack/triodumper.py
@@ -41,7 +41,7 @@ def _dump_str(str_value: str) -> str:
         if str_value.endswith("\n  "):
             str_value = str_value[:-3]
         return str_value
-    if str_value not in ["T", "F", "NA", "R", "N", "M"] \
+    if str_value in ["T", "F", "NA", "R", "N", "M"] \
             and _REGULAR_STR.match(str_value):
         return str_value
     return '"%s"' % str_value


### PR DESCRIPTION
When i try to dumd the next trio file : 
---
id: @muz.A.r1
dis: "1er etage bâtiment A"
space: M
floor: M
floorNum: 2.0
siteRef: @muz

I got 
---
id: @muz.A.r1
dis: 1er etage bâtiment A
space: M
floor: M
floorNum: 2.0
siteRef: @muz


But I expect : 
---
id: @muz.A.r1
dis: "1er etage bâtiment A"
space: M
floor: M
floorNum: 2.0
siteRef: @muz


