### PR TITLE
Fixing caching issue when REFRESH is 0

### DIFF
--- a/docs/athena_provider.md
+++ b/docs/athena_provider.md
@@ -115,24 +115,6 @@ Refer to this [link](https://docs.aws.amazon.com/athena/latest/ug/udf-iam-access
 
 
 ### Limitation
- "db_name": "data base name",
-            "table_name": "table name",
-            "partition_keys": "partition keys key1='value1'/key2='value2'/.../key(n)='value(n)",
-            "hs_type": "type of timeseries (composit: dict or simple: float or string)",
-            "hs_value_column": { 
-                "column1": "float",
-                "column2": "float",
-                ...
-                "column(n)": "float"
-            },
-            "hs_date_column": {
-                "time": "%Y-%m-%d %H:%M:%S.%f"
-            },
-            "date_part_keys": {
-                "year_col": "year",
-                "month_col": "month",
-                "day_col": "day"
-            }
 - The entities with history must have the following tags: `db_name`,`table_name`,`partition_keys`, `hs_type`,`hs_value_column`,`hs_date_column`, `date_part_keys` that will be used to build an Athena query
 - Athena is a **multi tenant service** and not indeed not a low latency data store. All users are competing for resources, and your queries will get queued when there aren't enough resources available 
 - More details [here](https://aws.amazon.com/athena/?whats-new-cards.sort-by=item.additionalFields.postDateTime&whats-new-cards.sort-order=desc)

--- a/docs/athena_provider.md
+++ b/docs/athena_provider.md
@@ -1,0 +1,122 @@
+# Provider + AWS Athena
+
+This provider extends the `DBProvider` to manage time-series with
+[AWS Athena](https://docs.aws.amazon.com/athena/). 
+
+Use `HAYSTACK_PROVIDER=shaytack.providers.athena` to use
+this provider. Add the variable `HAYSTACK_DB` to describe the link to the backend to read the ontology and `HAYSTACK_TS`
+to describe required elements to run Athena queries. 
+
+The format of `HAYSTACK_TS` is :
+
+    athena://shaystack?output_bucket_name=<S3 bucket name>&output_folder_name=<output folder>
+- **output_bucket_name [REQUIRED]**: The name of the bucket in which Athena will store the query results
+- **output_folder_name [REQUIRED]**: The folder name in which Athena will store the query results
+
+### hisURI structure
+**hisURI** in the ontology definition contains all the elements required to query Athena databases and retrieve time series data according to the information given inside **hisURI** whose structure should be as follows:
+```
+"hisURI": {
+            "db_name": "data base name",
+            "table_name": "table name",
+            "partition_keys": "partition keys key1='value1'/key2='value2'/.../key(n)='value(n)",
+            "hs_type": "type of timeseries (composit: dict or simple: float or string)",
+            "hs_value_column": { 
+                "column1": "float",
+                "column2": "float",
+                ...
+                "column(n)": "float"
+            },
+            "hs_date_column": {
+                "time": "%Y-%m-%d %H:%M:%S.%f"
+            },
+            "date_part_keys": {
+                "year_col": "year",
+                "month_col": "month",
+                "day_col": "day"
+            }
+        }
+```
+- **db_name**: the name of the databases from the AWS data catalog
+- **table_name**: the name of the table within the database
+- **partition_keys**: one or more partition keys separated by "/" used
+  to partition the data, could be partitioned by year, month, date, and hour `"partition_keys": "key1='val1'/key2='val2'"`
+- **hs_type**: it could be:
+  - **a composite type** like **dict** {"col1": value1, "col2": value2, ...}
+  - **a simple type** like **float**, **int**, **string** or **bool**
+- **hs_value_column**: if the type is **dict**, it should contain one or more column `names` and the `type` corresponding to each of them; if the type is simple, it should contain the column `name` and its `type`
+- **hs_date_column**: the name of the column that represents the `timestamp` of the time series followed by ":" and the `datetime format`, for example: `"time": "%Y-%m-%d %H:%M:%S.%f"`
+- **date_part_keys**: Time series can be partitioned by date elements such as year, month and day, and all partition keys used must be specified with their name used when creating the table  as follows:
+
+      "date_part_keys":{
+         "year_col": "year column name",
+         "month_col": "month column name",
+         "day_col": "day column name"
+      }
+
+You can create **Athena tables**, using *[AWS Glue](https://docs.aws.amazon.com/athena/latest/ug/creating-tables.html#:~:text=in%20Amazon%20S3.-,Creating%20tables%20using%20AWS%20Glue%20or%20the%20Athena%20console,-You%20can%20create)* or by running a *[DDL statement in the Athena query editor](https://docs.aws.amazon.com/athena/latest/ug/creating-tables.html#:~:text=To%20create%20a%20table%20using%20Hive%20DDL)*.
+
+### Running Haystack Api 
+
+```console
+$ HAYSTACK_PROVIDER=shaystack.providers.athena \
+  HAYSTACK_DB=sample/athena_sample.hayson.json \
+  HAYSTACK_TS=athena://shaystack?output_bucket_name=bucket_name&output_folder_name=folder_name \
+  shaystack
+```
+
+### Requirements
+In order to use the **Athena provider**, ensure that the IAM role or another IAM principal has the required permissions to access the source data bucket and the query result bucket, as well as Athena permissions to execute Athena queries.
+- **athena** – Allows principals access to Athena resources.
+- **s3** – Allows the principal to write and read query results from Amazon S3, to read publically available Athena data examples that reside in Amazon S3, and to list buckets. This is required so that the principal can use Athena to work with Amazon S3.
+
+**Example** – The following identity-based permissions policy allows actions that a user or other IAM principal requires to run queries that use Athena UDF statements
+
+  ```{
+      "Version": "2012-10-17",
+      "Statement": [
+          {
+              "Sid": "VisualEditor0",
+              "Effect": "Allow",
+              "Action": [
+                  "athena:StartQueryExecution",
+                  "lambda:InvokeFunction",
+                  "athena:GetQueryResults",
+                  "s3:ListMultipartUploadParts",
+                  "athena:GetWorkGroup",
+                  "s3:PutObject",
+                  "s3:GetObject",
+                  "s3:AbortMultipartUpload",
+                  "athena:StopQueryExecution",
+                  "athena:GetQueryExecution",
+                  "s3:GetBucketLocation"
+              ],
+              "Resource": [
+                  "arn:aws:athena:*:MyAWSAcctId:workgroup/MyAthenaWorkGroup",
+                  "arn:aws:s3:::MyQueryResultsBucket/*",
+                  "arn:aws:lambda:*:MyAWSAcctId:function:OneAthenaLambdaFunction",
+                  "arn:aws:lambda:*:MyAWSAcctId:function:AnotherAthenaLambdaFunction"
+              ]
+          },
+          {
+              "Sid": "VisualEditor1",
+              "Effect": "Allow",
+              "Action": "athena:ListWorkGroups",
+              "Resource": "*"
+          }
+      ]
+  }
+  ```
+Refer to this [link](https://docs.aws.amazon.com/athena/latest/ug/udf-iam-access.html) for more details on the Athena permissions policy requirements.
+
+
+
+
+
+
+### Limitation
+
+- The entities with history must have a tag `kind` to describe the type of values and a tag `id`
+- Athena is a **multi tenant service** and not indeed not a low latency data store. All users are competing for resources, and your queries will get queued when there aren't enough resources available 
+- More details [here](https://aws.amazon.com/athena/?whats-new-cards.sort-by=item.additionalFields.postDateTime&whats-new-cards.sort-order=desc)
+

--- a/docs/athena_provider.md
+++ b/docs/athena_provider.md
@@ -115,8 +115,25 @@ Refer to this [link](https://docs.aws.amazon.com/athena/latest/ug/udf-iam-access
 
 
 ### Limitation
-
-- The entities with history must have a tag `kind` to describe the type of values and a tag `id`
+ "db_name": "data base name",
+            "table_name": "table name",
+            "partition_keys": "partition keys key1='value1'/key2='value2'/.../key(n)='value(n)",
+            "hs_type": "type of timeseries (composit: dict or simple: float or string)",
+            "hs_value_column": { 
+                "column1": "float",
+                "column2": "float",
+                ...
+                "column(n)": "float"
+            },
+            "hs_date_column": {
+                "time": "%Y-%m-%d %H:%M:%S.%f"
+            },
+            "date_part_keys": {
+                "year_col": "year",
+                "month_col": "month",
+                "day_col": "day"
+            }
+- The entities with history must have the following tags: `db_name`,`table_name`,`partition_keys`, `hs_type`,`hs_value_column`,`hs_date_column`, `date_part_keys` that will be used to build an Athena query
 - Athena is a **multi tenant service** and not indeed not a low latency data store. All users are competing for resources, and your queries will get queued when there aren't enough resources available 
 - More details [here](https://aws.amazon.com/athena/?whats-new-cards.sort-by=item.additionalFields.postDateTime&whats-new-cards.sort-order=desc)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -257,7 +257,6 @@ by extending `shaystack.providers.HaystackInterface`
 |Data in a MySQL database|`HAYSTACK_PROVIDER=shaystack.providers.db \`<br/>` HAYSTACK_DB=mysql://... \`<br/>` shaystack`|Remember to install pymysql python module. [More...](sql_provider.md)|
 |Data in a MongoDB|`HAYSTACK_PROVIDER=shaystack.providers.db\`<br/>`HAYSTACK_DB=mongodb+srv:://...\`<br/>` shaystack`|Remember to install pymongo python module. [More...](mongo_provider.md)|
 |Data in a database and Time series in AWS Time Stream|`HAYSTACK_PROVIDER=shaystack.providers.timestream\`<br/>`HAYSTACK_DB=...\`<br/>`HAYSTACK_TS=timestream:://...\<br /> shaystack`|[More...](timestream_provider.md)|
-|Data in a database and Time series in AWS Time Stream|`HAYSTACK_PROVIDER=shaystack.providers.timestream\`<br/>`HAYSTACK_DB=...\`<br/>`HAYSTACK_TS=timestream:://...\<br /> shaystack`|[More...](timestream_provider.md)|
 |Data in a database and Time series in AWS Athena|`HAYSTACK_PROVIDER=shaystack.providers.athena\`<br/>`HAYSTACK_DB=...\`<br/>`HAYSTACK_TS=athena:://...\<br /> shaystack`|[More...](athena_provider.md)|
 |Custom|`HAYSTACK_PROVIDER=shaystack.providers.<your module name>\`<br/>` shaystack`|Write your own subclass of `shaystack.providers.HaystackInterface|
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -257,7 +257,7 @@ by extending `shaystack.providers.HaystackInterface`
 |Data in a MySQL database|`HAYSTACK_PROVIDER=shaystack.providers.db \`<br/>` HAYSTACK_DB=mysql://... \`<br/>` shaystack`|Remember to install pymysql python module. [More...](sql_provider.md)|
 |Data in a MongoDB|`HAYSTACK_PROVIDER=shaystack.providers.db\`<br/>`HAYSTACK_DB=mongodb+srv:://...\`<br/>` shaystack`|Remember to install pymongo python module. [More...](mongo_provider.md)|
 |Data in a database and Time series in AWS Time Stream|`HAYSTACK_PROVIDER=shaystack.providers.timestream\`<br/>`HAYSTACK_DB=...\`<br/>`HAYSTACK_TS=timestream:://...\<br /> shaystack`|[More...](timestream_provider.md)|
-| Data in a database and Time series in AWS Athena|`HAYSTACK_PROVIDER=shaystack.providers.athena\`<br/>`HAYSTACK_DB=...\`<br/>`HAYSTACK_TS=athena:://...\<br /> shaystack`|[More...](athena_provider.md)|
+|Data in a database and Time series in AWS Athena|`HAYSTACK_PROVIDER=shaystack.providers.athena\`<br/>`HAYSTACK_DB=...\`<br/>`HAYSTACK_TS=athena:://...\<br /> shaystack`|[More...](athena_provider.md)|
 |Custom|`HAYSTACK_PROVIDER=shaystack.providers.<your module name>\`<br/>` shaystack`|Write your own subclass of `shaystack.providers.HaystackInterface|
 
 *Note: Existing providers are not connected to IOT for simplicity. If you want to connect the haystack API with IOT, you

--- a/docs/index.md
+++ b/docs/index.md
@@ -257,6 +257,7 @@ by extending `shaystack.providers.HaystackInterface`
 |Data in a MySQL database|`HAYSTACK_PROVIDER=shaystack.providers.db \`<br/>` HAYSTACK_DB=mysql://... \`<br/>` shaystack`|Remember to install pymysql python module. [More...](sql_provider.md)|
 |Data in a MongoDB|`HAYSTACK_PROVIDER=shaystack.providers.db\`<br/>`HAYSTACK_DB=mongodb+srv:://...\`<br/>` shaystack`|Remember to install pymongo python module. [More...](mongo_provider.md)|
 |Data in a database and Time series in AWS Time Stream|`HAYSTACK_PROVIDER=shaystack.providers.timestream\`<br/>`HAYSTACK_DB=...\`<br/>`HAYSTACK_TS=timestream:://...\<br /> shaystack`|[More...](timestream_provider.md)|
+|Data in a database and Time series in AWS Time Stream|`HAYSTACK_PROVIDER=shaystack.providers.timestream\`<br/>`HAYSTACK_DB=...\`<br/>`HAYSTACK_TS=timestream:://...\<br /> shaystack`|[More...](timestream_provider.md)|
 |Data in a database and Time series in AWS Athena|`HAYSTACK_PROVIDER=shaystack.providers.athena\`<br/>`HAYSTACK_DB=...\`<br/>`HAYSTACK_TS=athena:://...\<br /> shaystack`|[More...](athena_provider.md)|
 |Custom|`HAYSTACK_PROVIDER=shaystack.providers.<your module name>\`<br/>` shaystack`|Write your own subclass of `shaystack.providers.HaystackInterface|
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -245,20 +245,20 @@ You can mix two or more options, if you need them all, use `pip install "shaysta
 Depending on where and how your haystack data is stored, you need to choose an existing Provider or implement your own
 by extending `shaystack.providers.HaystackInterface`
 
-| Where is data stored                                  | Shell command                                                                                                                   | Miscellaneous                                                                       |
-|-------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|
-| No data, just testing                                 | `HAYSTACK_PROVIDER=shaystack.providers.ping \`<br/>` shaystack`                                                                 ||
-| Data on http server                                   | `HAYSTACK_PROVIDER=shaystack.providers.db \`<br/>` HAYSTACK_DB=http://... \`<br/>` shaystack`                                   | [More...](url_provider.md)                                                          |
-| Data on ftp server                                    | `HAYSTACK_PROVIDER=shaystack.providers.db \`<br/>` HAYSTACK_DB=ftp://... \`<br/>` shaystack`                                    | [More...](url_provider.md)                                                          |
-| Data on local filesystem                              | `HAYSTACK_PROVIDER=shaystack.providers.db \`<br/>` HAYSTACK_DB=file://... \`<br/>` shaystack`                                   | [More...](url_provider.md)                                                          |
-| Data on AWS S3 Bucket                                 | `HAYSTACK_PROVIDER=shaystack.providers.db \`<br/>` HAYSTACK_DB=s3://... \`<br/>` shaystack`                                     | Remember to install aws support and boto3 python module. [More...](url_provider.md) |
-| Data in a SuperSQLite database                        | `HAYSTACK_PROVIDER=shaystack.providers.db \`<br/>` HAYSTACK_DB=sqlite3://... \`<br/>` shaystack`                                | Remember to install Supersqlite python module. [More...](sql_provider.md)           |
-| Data in a Postgresql database                         | `HAYSTACK_PROVIDER=shaystack.providers.db \`<br/>` HAYSTACK_DB=postgres://... \`<br/>` shaystack`                               | Remember to install psycopg2 python module. [More...](sql_provider.md)              |
-| Data in a MySQL database                              | `HAYSTACK_PROVIDER=shaystack.providers.db \`<br/>` HAYSTACK_DB=mysql://... \`<br/>` shaystack`                                  | Remember to install pymysql python module. [More...](sql_provider.md)               |
-| Data in a MongoDB                                     | `HAYSTACK_PROVIDER=shaystack.providers.db\`<br/>`HAYSTACK_DB=mongodb+srv:://...\`<br/>` shaystack`                              | Remember to install pymongo python module. [More...](mongo_provider.md)             |
-| Data in a database and Time series in AWS Time Stream | `HAYSTACK_PROVIDER=shaystack.providers.timestream\`<br/>`HAYSTACK_DB=...\`<br/>`HAYSTACK_TS=timestream:://...\<br /> shaystack` | [More...](timestream_provider.md)                                                   |
-| Data in a database and Time series in AWS Athena      | `HAYSTACK_PROVIDER=shaystack.providers.athena\`<br/>`HAYSTACK_DB=...\`<br/>`HAYSTACK_TS=athena:://...\<br /> shaystack`         | [More...](athena_provider.md)                                                       |
-| Custom                                                | `HAYSTACK_PROVIDER=shaystack.providers.<your module name>\`<br/>` shaystack`                                                    | Write your own subclass of `shaystack.providers.HaystackInterface                   |
+|Where is data stored|Shell command|Miscellaneous|
+|---|---|---|
+|No data, just testing|`HAYSTACK_PROVIDER=shaystack.providers.ping \`<br/>` shaystack`||
+|Data on http server|`HAYSTACK_PROVIDER=shaystack.providers.db \`<br/>` HAYSTACK_DB=http://... \`<br/>` shaystack`|[More...](url_provider.md)|
+|Data on ftp server|`HAYSTACK_PROVIDER=shaystack.providers.db \`<br/>` HAYSTACK_DB=ftp://... \`<br/>` shaystack`|[More...](url_provider.md)|
+|Data on local filesystem|`HAYSTACK_PROVIDER=shaystack.providers.db \`<br/>` HAYSTACK_DB=file://... \`<br/>` shaystack`|[More...](url_provider.md)|
+|Data on AWS S3 Bucket|`HAYSTACK_PROVIDER=shaystack.providers.db \`<br/>` HAYSTACK_DB=s3://... \`<br/>` shaystack`|Remember to install aws support and boto3 python module. [More...](url_provider.md)|
+|Data in a SuperSQLite database|`HAYSTACK_PROVIDER=shaystack.providers.db \`<br/>` HAYSTACK_DB=sqlite3://... \`<br/>` shaystack`|Remember to install Supersqlite python module. [More...](sql_provider.md)|
+|Data in a Postgresql database|`HAYSTACK_PROVIDER=shaystack.providers.db \`<br/>` HAYSTACK_DB=postgres://... \`<br/>` shaystack`|Remember to install psycopg2 python module. [More...](sql_provider.md)|
+|Data in a MySQL database|`HAYSTACK_PROVIDER=shaystack.providers.db \`<br/>` HAYSTACK_DB=mysql://... \`<br/>` shaystack`|Remember to install pymysql python module. [More...](sql_provider.md)|
+|Data in a MongoDB|`HAYSTACK_PROVIDER=shaystack.providers.db\`<br/>`HAYSTACK_DB=mongodb+srv:://...\`<br/>` shaystack`|Remember to install pymongo python module. [More...](mongo_provider.md)|
+|Data in a database and Time series in AWS Time Stream|`HAYSTACK_PROVIDER=shaystack.providers.timestream\`<br/>`HAYSTACK_DB=...\`<br/>`HAYSTACK_TS=timestream:://...\<br /> shaystack`|[More...](timestream_provider.md)|
+| Data in a database and Time series in AWS Athena|`HAYSTACK_PROVIDER=shaystack.providers.athena\`<br/>`HAYSTACK_DB=...\`<br/>`HAYSTACK_TS=athena:://...\<br /> shaystack`|[More...](athena_provider.md)|
+|Custom|`HAYSTACK_PROVIDER=shaystack.providers.<your module name>\`<br/>` shaystack`|Write your own subclass of `shaystack.providers.HaystackInterface|
 
 *Note: Existing providers are not connected to IOT for simplicity. If you want to connect the haystack API with IOT, you
 must implement a custom provider or extend one of them.*

--- a/docs/index.md
+++ b/docs/index.md
@@ -245,19 +245,20 @@ You can mix two or more options, if you need them all, use `pip install "shaysta
 Depending on where and how your haystack data is stored, you need to choose an existing Provider or implement your own
 by extending `shaystack.providers.HaystackInterface`
 
-|Where is data stored|Shell command|Miscellaneous|
-|---|---|---|
-|No data, just testing|`HAYSTACK_PROVIDER=shaystack.providers.ping \`<br/>` shaystack`||
-|Data on http server|`HAYSTACK_PROVIDER=shaystack.providers.db \`<br/>` HAYSTACK_DB=http://... \`<br/>` shaystack`|[More...](url_provider.md)|
-|Data on ftp server|`HAYSTACK_PROVIDER=shaystack.providers.db \`<br/>` HAYSTACK_DB=ftp://... \`<br/>` shaystack`|[More...](url_provider.md)|
-|Data on local filesystem|`HAYSTACK_PROVIDER=shaystack.providers.db \`<br/>` HAYSTACK_DB=file://... \`<br/>` shaystack`|[More...](url_provider.md)|
-|Data on AWS S3 Bucket|`HAYSTACK_PROVIDER=shaystack.providers.db \`<br/>` HAYSTACK_DB=s3://... \`<br/>` shaystack`|Remember to install aws support and boto3 python module. [More...](url_provider.md)|
-|Data in a SuperSQLite database|`HAYSTACK_PROVIDER=shaystack.providers.db \`<br/>` HAYSTACK_DB=sqlite3://... \`<br/>` shaystack`|Remember to install Supersqlite python module. [More...](sql_provider.md)|
-|Data in a Postgresql database|`HAYSTACK_PROVIDER=shaystack.providers.db \`<br/>` HAYSTACK_DB=postgres://... \`<br/>` shaystack`|Remember to install psycopg2 python module. [More...](sql_provider.md)|
-|Data in a MySQL database|`HAYSTACK_PROVIDER=shaystack.providers.db \`<br/>` HAYSTACK_DB=mysql://... \`<br/>` shaystack`|Remember to install pymysql python module. [More...](sql_provider.md)|
-|Data in a MongoDB|`HAYSTACK_PROVIDER=shaystack.providers.db\`<br/>`HAYSTACK_DB=mongodb+srv:://...\`<br/>` shaystack`|Remember to install pymongo python module. [More...](mongo_provider.md)|
-|Data in a database and Time series in AWS Time Stream|`HAYSTACK_PROVIDER=shaystack.providers.timestream\`<br/>`HAYSTACK_DB=...\`<br/>`HAYSTACK_TS=timestream:://...\<br /> shaystack`|[More...](timestream_provider.md)|
-|Custom|`HAYSTACK_PROVIDER=shaystack.providers.<your module name>\`<br/>` shaystack`|Write your own subclass of `shaystack.providers.HaystackInterface|
+| Where is data stored                                  | Shell command                                                                                                                   | Miscellaneous                                                                       |
+|-------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|
+| No data, just testing                                 | `HAYSTACK_PROVIDER=shaystack.providers.ping \`<br/>` shaystack`                                                                 ||
+| Data on http server                                   | `HAYSTACK_PROVIDER=shaystack.providers.db \`<br/>` HAYSTACK_DB=http://... \`<br/>` shaystack`                                   | [More...](url_provider.md)                                                          |
+| Data on ftp server                                    | `HAYSTACK_PROVIDER=shaystack.providers.db \`<br/>` HAYSTACK_DB=ftp://... \`<br/>` shaystack`                                    | [More...](url_provider.md)                                                          |
+| Data on local filesystem                              | `HAYSTACK_PROVIDER=shaystack.providers.db \`<br/>` HAYSTACK_DB=file://... \`<br/>` shaystack`                                   | [More...](url_provider.md)                                                          |
+| Data on AWS S3 Bucket                                 | `HAYSTACK_PROVIDER=shaystack.providers.db \`<br/>` HAYSTACK_DB=s3://... \`<br/>` shaystack`                                     | Remember to install aws support and boto3 python module. [More...](url_provider.md) |
+| Data in a SuperSQLite database                        | `HAYSTACK_PROVIDER=shaystack.providers.db \`<br/>` HAYSTACK_DB=sqlite3://... \`<br/>` shaystack`                                | Remember to install Supersqlite python module. [More...](sql_provider.md)           |
+| Data in a Postgresql database                         | `HAYSTACK_PROVIDER=shaystack.providers.db \`<br/>` HAYSTACK_DB=postgres://... \`<br/>` shaystack`                               | Remember to install psycopg2 python module. [More...](sql_provider.md)              |
+| Data in a MySQL database                              | `HAYSTACK_PROVIDER=shaystack.providers.db \`<br/>` HAYSTACK_DB=mysql://... \`<br/>` shaystack`                                  | Remember to install pymysql python module. [More...](sql_provider.md)               |
+| Data in a MongoDB                                     | `HAYSTACK_PROVIDER=shaystack.providers.db\`<br/>`HAYSTACK_DB=mongodb+srv:://...\`<br/>` shaystack`                              | Remember to install pymongo python module. [More...](mongo_provider.md)             |
+| Data in a database and Time series in AWS Time Stream | `HAYSTACK_PROVIDER=shaystack.providers.timestream\`<br/>`HAYSTACK_DB=...\`<br/>`HAYSTACK_TS=timestream:://...\<br /> shaystack` | [More...](timestream_provider.md)                                                   |
+| Data in a database and Time series in AWS Athena      | `HAYSTACK_PROVIDER=shaystack.providers.athena\`<br/>`HAYSTACK_DB=...\`<br/>`HAYSTACK_TS=athena:://...\<br /> shaystack`         | [More...](athena_provider.md)                                                       |
+| Custom                                                | `HAYSTACK_PROVIDER=shaystack.providers.<your module name>\`<br/>` shaystack`                                                    | Write your own subclass of `shaystack.providers.HaystackInterface                   |
 
 *Note: Existing providers are not connected to IOT for simplicity. If you want to connect the haystack API with IOT, you
 must implement a custom provider or extend one of them.*

--- a/shaystack/providers/url.py
+++ b/shaystack/providers/url.py
@@ -566,6 +566,8 @@ class Provider(DBHaystackInterface):  # pylint: disable=too-many-instance-attrib
         minutes_delta = now.minute
         if self._periodic_refresh != 0:
             minutes_delta = (now.minute + self._periodic_refresh) // self._periodic_refresh * self._periodic_refresh
+        else:
+            self.cache_clear()
         next_time = now.replace(minute=0) + timedelta(minutes=minutes_delta)
         assert next_time >= now
         if parsed_uri.scheme == "s3":

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -49,3 +49,40 @@ def _get_mock_s3():
             return stream.write(dump(self.history, mode=MODE_ZINC).encode("utf-8"))
 
     return MockS3()
+
+def _get_mock_s3_updated_ontology():
+    sample_grid = Grid(version=VER_3_0, columns=["id", "col", "hisURI"])
+    sample_grid.append({"id": Ref("id1"), "col": 1, "hisURI": "hist.zinc"})
+    sample_grid.append({"id": Ref("id2"), "col": 2, "hisURI": "hist.zinc"})
+    sample_grid.append({"id": Ref("id3"), "col": 3, "hisURI": "hist.zinc"})
+    version_1 = datetime(2020, 10, 1, 0, 0, 1, 0, tzinfo=pytz.UTC)
+
+    class MockS3:
+        __slots__ = "history", "his_count"
+
+        def __init__(self):
+            self.history = None
+            self.his_count = 0
+
+        def list_object_versions(self, **args):
+            return {
+                "Versions":
+                    [
+                        {"VersionId": "1", "LastModified": version_1}
+                    ]
+            }
+
+        def download_fileobj(self, bucket, path, stream, **params):
+            if path == "grid.zinc":
+                grid = sample_grid.copy()
+                if params.get("ExtraArgs", None):
+                    grid.metadata = {"v": params["ExtraArgs"]["VersionId"]}
+                else:
+                    grid.metadata = {"v": "last"}
+                for row in grid:
+                    row["hisURI"] = f"his{self.his_count}.zinc"
+                    self.his_count += 1
+                return stream.write(dump(grid, mode=MODE_ZINC).encode("utf-8"))
+            return stream.write(dump(self.history, mode=MODE_ZINC).encode("utf-8"))
+
+    return MockS3()

--- a/tests/test_refresh_zero.py
+++ b/tests/test_refresh_zero.py
@@ -13,6 +13,7 @@ from shaystack.providers import get_provider
 from shaystack.providers.url import Provider as URLProvider
 from tests import _get_mock_s3, _get_mock_s3_updated_ontology
 
+
 @patch.object(URLProvider, '_get_url')
 @patch.object(URLProvider, '_s3')
 def test_read_last_with_refresh_zero(mock_s3, mock_get_url):
@@ -23,7 +24,10 @@ def test_read_last_with_refresh_zero(mock_s3, mock_get_url):
     """
 
     mock_get_url.return_value = "s3://bucket/grid.zinc"
-    with cast(URLProvider, get_provider("shaystack.providers.url", {"REFRESH": 0})) as provider:
+    with cast(URLProvider, get_provider("shaystack.providers.url", {})) as provider:
+
+        provider.cache_clear()
+        provider._periodic_refresh = 0
 
         mock_s3.return_value = _get_mock_s3()
         result1 = provider.read(0, None, None, None, None)
@@ -35,7 +39,6 @@ def test_read_last_with_refresh_zero(mock_s3, mock_get_url):
         assert len(result2._row) == 3
         assert len(result1._row) != len(result2._row)
 
-
 @patch.object(URLProvider, '_get_url')
 @patch.object(URLProvider, '_s3')
 def test_read_last_with_refresh__not_zero(mock_s3, mock_get_url):
@@ -46,7 +49,10 @@ def test_read_last_with_refresh__not_zero(mock_s3, mock_get_url):
     """
 
     mock_get_url.return_value = "s3://bucket/grid.zinc"
-    with cast(URLProvider, get_provider("shaystack.providers.url", {"REFRESH": 15})) as provider:
+    with cast(URLProvider, get_provider("shaystack.providers.url", {})) as provider:
+
+        provider.cache_clear()
+        provider._periodic_refresh = 15
 
         mock_s3.return_value = _get_mock_s3()
         result1 = provider.read(0, None, None, None, None)

--- a/tests/test_refresh_zero.py
+++ b/tests/test_refresh_zero.py
@@ -1,0 +1,59 @@
+from typing import cast
+from unittest.mock import patch
+
+from datetime import datetime
+
+import pytz
+
+from shaystack.dumper import dump
+from shaystack.grid import Grid, VER_3_0
+from shaystack.parser import MODE_ZINC
+from shaystack import Ref
+from shaystack.providers import get_provider
+from shaystack.providers.url import Provider as URLProvider
+from tests import _get_mock_s3, _get_mock_s3_updated_ontology
+
+@patch.object(URLProvider, '_get_url')
+@patch.object(URLProvider, '_s3')
+def test_read_last_with_refresh_zero(mock_s3, mock_get_url):
+    """
+    Args:
+        mock_s3:
+        mock_get_url:
+    """
+
+    mock_get_url.return_value = "s3://bucket/grid.zinc"
+    with cast(URLProvider, get_provider("shaystack.providers.url", {"REFRESH": 0})) as provider:
+
+        mock_s3.return_value = _get_mock_s3()
+        result1 = provider.read(0, None, None, None, None)
+
+        mock_s3.return_value = _get_mock_s3_updated_ontology()
+        result2 = provider.read(0, None, None, None, None)
+
+        assert len(result1._row) == 2
+        assert len(result2._row) == 3
+        assert len(result1._row) != len(result2._row)
+
+
+@patch.object(URLProvider, '_get_url')
+@patch.object(URLProvider, '_s3')
+def test_read_last_with_refresh__not_zero(mock_s3, mock_get_url):
+    """
+    Args:
+        mock_s3:
+        mock_get_url:
+    """
+
+    mock_get_url.return_value = "s3://bucket/grid.zinc"
+    with cast(URLProvider, get_provider("shaystack.providers.url", {"REFRESH": 15})) as provider:
+
+        mock_s3.return_value = _get_mock_s3()
+        result1 = provider.read(0, None, None, None, None)
+
+        mock_s3.return_value = _get_mock_s3_updated_ontology()
+        result2 = provider.read(0, None, None, None, None)
+
+        assert len(result1._row) == 2
+        assert len(result2._row) == 2
+        assert len(result1._row) == len(result2._row)


### PR DESCRIPTION
The reason behind the caching problem is the fact of using the `@functools.cached_property(func)` decorator to wrap the [method](https://github.com/engie-group/shaystack/blob/fix/github_actions/shaystack/providers/url.py#:~:text=%40functools.,%2D%3E%20Grid%3A) that downloads the ontology version.
This decorator turns a method into a property whose value is calculated once and then cached as a normal attribute for the lifetime of the instance 

I have implemented the test that allows us to easily detect this problem and there are two ways to avoid it

- by setting the variable that is used to indicate how long the function will be cached, which is _LRU_SIZE in url.py,

- or by using the function that has been implemented to clear the provider cache, which is `provider.cache_clear()` 